### PR TITLE
Set link name from rosparam for test_stability.cpp

### DIFF
--- a/include/hrl_kinematics/Kinematics.h
+++ b/include/hrl_kinematics/Kinematics.h
@@ -72,7 +72,7 @@ public:
     : std::runtime_error(what) {}
   };
 
-  Kinematics(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_);
+  Kinematics(std::string _root_link_name_, std::string _rfoot_link_name_, std::string _lfoot_link_name_);
   Kinematics();
   virtual ~Kinematics();
   void initialize();

--- a/include/hrl_kinematics/Kinematics.h
+++ b/include/hrl_kinematics/Kinematics.h
@@ -72,8 +72,10 @@ public:
     : std::runtime_error(what) {}
   };
 
+  Kinematics(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_);
   Kinematics();
   virtual ~Kinematics();
+  void initialize();
 
   /**
    * Computes the center of mass of the given robot structure and joint configuration.

--- a/include/hrl_kinematics/TestStability.h
+++ b/include/hrl_kinematics/TestStability.h
@@ -51,7 +51,7 @@ namespace hrl_kinematics {
 class TestStability : public Kinematics{
 public:
   TestStability();
-  TestStability(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_, const std::string _rfoot_mesh_link_name_);
+  TestStability(std::string _root_link_name_, std::string _rfoot_link_name_, std::string _lfoot_link_name_, std::string _rfoot_mesh_link_name_);
   virtual ~TestStability();
 
   /**

--- a/include/hrl_kinematics/TestStability.h
+++ b/include/hrl_kinematics/TestStability.h
@@ -51,6 +51,7 @@ namespace hrl_kinematics {
 class TestStability : public Kinematics{
 public:
   TestStability();
+  TestStability(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_, const std::string _rfoot_mesh_link_name_);
   virtual ~TestStability();
 
   /**

--- a/src/Kinematics.cpp
+++ b/src/Kinematics.cpp
@@ -35,7 +35,7 @@ using robot_state_publisher::SegmentPair;
 
 namespace hrl_kinematics {
 
-Kinematics::Kinematics(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_)
+Kinematics::Kinematics(std::string _root_link_name_, std::string _rfoot_link_name_, std::string _lfoot_link_name_)
 : nh_(), nh_private_ ("~"),
   root_link_name_(_root_link_name_), rfoot_link_name_(_rfoot_link_name_),  lfoot_link_name_(_lfoot_link_name_)
 {

--- a/src/Kinematics.cpp
+++ b/src/Kinematics.cpp
@@ -35,10 +35,25 @@ using robot_state_publisher::SegmentPair;
 
 namespace hrl_kinematics {
 
+Kinematics::Kinematics(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_)
+: nh_(), nh_private_ ("~"),
+  root_link_name_(_root_link_name_), rfoot_link_name_(_rfoot_link_name_),  lfoot_link_name_(_lfoot_link_name_)
+{
+    initialize();
+}
+
 Kinematics::Kinematics()
 : nh_(), nh_private_ ("~"),
   root_link_name_("base_link"), rfoot_link_name_("r_sole"),  lfoot_link_name_("l_sole")
 {
+  initialize();
+}
+
+Kinematics::~Kinematics() {
+
+}
+
+void Kinematics::initialize() {
   // Get URDF XML
   std::string urdf_xml, full_urdf_xml;
   nh_private_.param("robot_description_name",urdf_xml,std::string("robot_description"));
@@ -57,11 +72,6 @@ Kinematics::Kinematics()
     throw Kinematics::InitFailed("Could not load models!");
 
   ROS_INFO("Kinematics initialized");
-
-}
-
-Kinematics::~Kinematics() {
-
 }
 
 bool Kinematics::loadModel(const std::string xml) {

--- a/src/TestStability.cpp
+++ b/src/TestStability.cpp
@@ -38,6 +38,13 @@ using boost::shared_ptr;
 
 namespace hrl_kinematics {
 
+TestStability::TestStability(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_, const std::string _rfoot_mesh_link_name_)
+: Kinematics(_root_link_name_, _rfoot_link_name_, _lfoot_link_name_), rfoot_mesh_link_name(_rfoot_mesh_link_name_)
+{
+  //Build support polygon with default scale 1.0
+  initFootPolygon(1.0);
+}
+
 TestStability::TestStability()
 : Kinematics(), rfoot_mesh_link_name("RAnkleRoll_link")
 {

--- a/src/TestStability.cpp
+++ b/src/TestStability.cpp
@@ -38,7 +38,7 @@ using boost::shared_ptr;
 
 namespace hrl_kinematics {
 
-TestStability::TestStability(const std::string _root_link_name_, const std::string _rfoot_link_name_, const std::string _lfoot_link_name_, const std::string _rfoot_mesh_link_name_)
+TestStability::TestStability(std::string _root_link_name_, std::string _rfoot_link_name_, std::string _lfoot_link_name_, std::string _rfoot_mesh_link_name_)
 : Kinematics(_root_link_name_, _rfoot_link_name_, _lfoot_link_name_), rfoot_mesh_link_name(_rfoot_mesh_link_name_)
 {
   //Build support polygon with default scale 1.0

--- a/src/test_stability.cpp
+++ b/src/test_stability.cpp
@@ -42,8 +42,8 @@ namespace hrl_kinematics {
  */
 class TestStabilityNode {
 public:
-  TestStabilityNode(Kinematics::FootSupport support, TestStability _test_stability_, ros::NodeHandle _nh_);
   TestStabilityNode(Kinematics::FootSupport support = Kinematics::SUPPORT_DOUBLE);
+  TestStabilityNode(ros::NodeHandle _nh_, TestStability _test_stability_, Kinematics::FootSupport support);
   virtual ~TestStabilityNode();
   void initialize();
   void jointStateCb(const sensor_msgs::JointStateConstPtr& state);
@@ -56,8 +56,8 @@ protected:
   Kinematics::FootSupport support_mode_;
 };
 
-TestStabilityNode::TestStabilityNode(Kinematics::FootSupport support, TestStability _test_stability_, ros::NodeHandle _nh_)
-: support_mode_ (support), test_stability_ (_test_stability_), nh_(_nh_)
+TestStabilityNode::TestStabilityNode(ros::NodeHandle _nh_, TestStability _test_stability_, Kinematics::FootSupport support)
+  : nh_(_nh_), test_stability_(_test_stability_), support_mode_ (support)
 {
   initialize();
 }
@@ -160,7 +160,7 @@ int main(int argc, char** argv)
       rfoot_mesh_link_name_ = "RAnkleRoll_link";
 
     hrl_kinematics::TestStability test_stability_(root_link_name_, rfoot_link_name_, lfoot_link_name_, rfoot_mesh_link_name_);
-    hrl_kinematics::TestStabilityNode StabilityNode(support, test_stability_, nh_);
+    hrl_kinematics::TestStabilityNode StabilityNode(nh_, test_stability_, support);
     // hrl_kinematics::TestStabilityNode StabilityNode(support);
 
     ros::spin();


### PR DESCRIPTION
I want to use test_stability.cpp for my robot, HRP-2.
But now, test_stability.cpp has no option for setting the name of support link.

In this pull request, test_stability.cpp set link name from rosparam.

"test_stability/root_link_name" for root_link_name_
"test_stability/rfoot_link_name" for rfoot_link_name_
"test_stability/lfoot_link_name" for lfoot_link_name_
"test_stability/rfoot_mesh_link_name" for rfoot_mesh_link_name_

of cause, if there is no rosparam, these values are set as the original values.

Thanks.
