### PR TITLE
Pass URDF Model As Ptr To Constructor

### DIFF
--- a/include/hrl_kinematics/Kinematics.h
+++ b/include/hrl_kinematics/Kinematics.h
@@ -72,7 +72,7 @@ public:
     : std::runtime_error(what) {}
   };
 
-  Kinematics();
+  Kinematics(const boost::shared_ptr<const urdf::ModelInterface>& urdf_model = boost::shared_ptr<const urdf::ModelInterface>());
   virtual ~Kinematics();
 
   /**
@@ -90,13 +90,14 @@ public:
 
 
   protected:
-  bool loadModel(const std::string xml);
+  bool loadKDLModel();
   void addChildren(const KDL::SegmentMap::const_iterator segment);
 
   void computeCOMRecurs(const KDL::SegmentMap::const_iterator& currentSeg, const std::map<std::string, double>& joint_positions,
                         const KDL::Frame& tf, KDL::Frame& tf_right_foot, KDL::Frame& tf_left_foot, double& m, KDL::Vector& cog);
   void createCoGMarker(const std::string& ns, const std::string& frame_id, double radius, const KDL::Vector& cog, visualization_msgs::Marker& marker) const;
-  urdf::Model urdf_model_;
+
+  boost::shared_ptr<const urdf::ModelInterface> urdf_model_;
   KDL::Tree kdl_tree_;
   KDL::Chain kdl_chain_right_;
   KDL::Chain kdl_chain_left_;

--- a/include/hrl_kinematics/TestStability.h
+++ b/include/hrl_kinematics/TestStability.h
@@ -50,7 +50,7 @@ namespace hrl_kinematics {
    */
 class TestStability : public Kinematics{
 public:
-  TestStability();
+  TestStability(const boost::shared_ptr<const urdf::ModelInterface>& urdf_model = boost::shared_ptr<const urdf::ModelInterface>());
   virtual ~TestStability();
 
   /**

--- a/src/Kinematics.cpp
+++ b/src/Kinematics.cpp
@@ -37,7 +37,7 @@ namespace hrl_kinematics {
 
 Kinematics::Kinematics()
 : nh_(), nh_private_ ("~"),
-  root_link_name_("base_link"), rfoot_link_name_("r_sole"),  lfoot_link_name_("l_sole")
+  root_link_name_("BODY"), rfoot_link_name_("RLEG_LINK5"),  lfoot_link_name_("LLEG_LINK5")
 {
   // Get URDF XML
   std::string urdf_xml, full_urdf_xml;

--- a/src/TestStability.cpp
+++ b/src/TestStability.cpp
@@ -38,8 +38,8 @@ using boost::shared_ptr;
 
 namespace hrl_kinematics {
 
-TestStability::TestStability()
-: Kinematics(), rfoot_mesh_link_name("RLEG_LINK5")
+TestStability::TestStability(const boost::shared_ptr<const urdf::ModelInterface>& urdf_model)
+: Kinematics(urdf_model), rfoot_mesh_link_name("RLEG_LINK5")
 {
   //Build support polygon with default scale 1.0
   initFootPolygon(1.0);
@@ -237,7 +237,7 @@ void TestStability::initFootPolygon(double scale_convex_hull){
 
 
 bool TestStability::loadFootPolygon(){
-  boost::shared_ptr<const urdf::Link> foot_link =  urdf_model_.getLink(rfoot_mesh_link_name);
+  boost::shared_ptr<const urdf::Link> foot_link =  urdf_model_->getLink(rfoot_mesh_link_name);
   assert(foot_link);
   boost::shared_ptr<const urdf::Geometry> geom;
   urdf::Pose geom_pose;

--- a/src/TestStability.cpp
+++ b/src/TestStability.cpp
@@ -323,7 +323,7 @@ bool TestStability::loadFootPolygon(){
 
   }
 
-  ROS_INFO("Foot polygon loaded with %zu points", foot_support_polygon_right_.size());
+  ROS_DEBUG("Foot polygon loaded with %zu points", foot_support_polygon_right_.size());
 
   return true;
 

--- a/src/TestStability.cpp
+++ b/src/TestStability.cpp
@@ -39,7 +39,7 @@ using boost::shared_ptr;
 namespace hrl_kinematics {
 
 TestStability::TestStability()
-: Kinematics(), rfoot_mesh_link_name("RAnkleRoll_link")
+: Kinematics(), rfoot_mesh_link_name("RLEG_LINK5")
 {
   //Build support polygon with default scale 1.0
   initFootPolygon(1.0);

--- a/src/test_stability.cpp
+++ b/src/test_stability.cpp
@@ -55,7 +55,7 @@ protected:
 };
 
 TestStabilityNode::TestStabilityNode(Kinematics::FootSupport support)
-: support_mode_ (support)
+: support_mode_(support)
 {
   ros::NodeHandle nh_private("~");
   visualization_pub_ = nh_private.advertise<visualization_msgs::MarkerArray>("stability_visualization", 1);


### PR DESCRIPTION
This PR speeds up the initialization of hrl_kinematics by providing the ability to pass in a `urdf::ModelInterface` object that has already parsed the URDF from the param server and loaded its kinematic tree. This PR:
- Speed up initialization through optional `urdf::ModelInterface` parameter
- Cleans up the constructor to provide default values for all the arguments, preserving backwards compatibility. 
- Adds inline documentation of arguments
- Renames loadModel to loadKDLModel
- Stores the `urdf::Model` member variable in a boost ptr.
- Fixes a few style inconsistencies
- Fixes a warning from usage of deprecated functions `tf::TransformKDLToTF`
