### PR TITLE
Set foot polygon scale constructor

### DIFF
--- a/include/hrl_kinematics/TestStability.h
+++ b/include/hrl_kinematics/TestStability.h
@@ -58,10 +58,12 @@ public:
    * \param rfoot_link_name - name of link that is considered the right foot
    * \param lfoot_link_name - name of link that is considered the left foot
    * \param urdf_model - a pointer to a pre-loaded URDF model that can speed up initialization if provided
+   * \param foot_polygon_scale - default 1.0 - determines the safety margin of the foot support polygon
    */
   TestStability(std::string rfoot_mesh_link_name = "RAnkleRoll_link", 
                 std::string root_link_name = "base_link", std::string rfoot_link_name = "r_sole", std::string lfoot_link_name = "l_sole",
-                const boost::shared_ptr<const urdf::ModelInterface>& urdf_model = boost::shared_ptr<const urdf::ModelInterface>());
+                const boost::shared_ptr<const urdf::ModelInterface>& urdf_model = boost::shared_ptr<const urdf::ModelInterface>(),
+                double foot_polygon_scale = 1.0);
 
   virtual ~TestStability();
 
@@ -112,7 +114,7 @@ protected:
   std::string rfoot_mesh_link_name_;
 
   //Convex Hull scaling factor
-  double scale_convex_hull_;
+  double foot_polygon_scale_;
 };
 
 // Create boost pointers for this class

--- a/src/TestStability.cpp
+++ b/src/TestStability.cpp
@@ -40,12 +40,13 @@ namespace hrl_kinematics {
 
 TestStability::TestStability(std::string rfoot_mesh_link_name, 
                              std::string root_link_name, std::string rfoot_link_name, std::string lfoot_link_name, 
-                             const boost::shared_ptr<const urdf::ModelInterface>& urdf_model)
+                             const boost::shared_ptr<const urdf::ModelInterface>& urdf_model,
+                             double foot_polygon_scale)
   : Kinematics(root_link_name, rfoot_link_name, lfoot_link_name, urdf_model)
   , rfoot_mesh_link_name_(rfoot_mesh_link_name)
 {
-  //Build support polygon with default scale 1.0
-  initFootPolygon(1.0);
+  //Build support polygon
+  initFootPolygon(foot_polygon_scale);
 }
 
 TestStability::~TestStability() {
@@ -213,10 +214,10 @@ bool TestStability::pointInConvexHull(const tf::Point& point, const std::vector<
   return true;
 }
 
-void TestStability::initFootPolygon(double scale_convex_hull){
+void TestStability::initFootPolygon(double foot_polygon_scale){
   
   //Init convex hull scaling factor
-  scale_convex_hull_ = scale_convex_hull;
+  foot_polygon_scale_ = foot_polygon_scale;
 
   // TODO: param?
   if (!loadFootPolygon()){
@@ -240,6 +241,9 @@ void TestStability::initFootPolygon(double scale_convex_hull){
 
 
 bool TestStability::loadFootPolygon(){
+
+  ROS_ERROR_STREAM_NAMED("temp","Loading foot polygon with scaling factor " << foot_polygon_scale_);
+
   boost::shared_ptr<const urdf::Link> foot_link =  urdf_model_->getLink(rfoot_mesh_link_name_);
   assert(foot_link);
   boost::shared_ptr<const urdf::Geometry> geom;
@@ -300,8 +304,8 @@ bool TestStability::loadFootPolygon(){
     tf::Point foot_point;
     for (unsigned int i = 0 ; i < foot_SP_right.size(); ++i){
       //Express point w.r.t foot center and directly apply scaling
-      foot_point.setX( (foot_SP_right[i].x() - r_foot_center.x()) * scale_convex_hull_ );
-      foot_point.setY( (foot_SP_right[i].y() - r_foot_center.y()) * scale_convex_hull_ );
+      foot_point.setX( (foot_SP_right[i].x() - r_foot_center.x()) * foot_polygon_scale_ );
+      foot_point.setY( (foot_SP_right[i].y() - r_foot_center.y()) * foot_polygon_scale_ );
       foot_SP_right_center.push_back(foot_point);
     }
 

--- a/src/TestStability.cpp
+++ b/src/TestStability.cpp
@@ -241,9 +241,6 @@ void TestStability::initFootPolygon(double foot_polygon_scale){
 
 
 bool TestStability::loadFootPolygon(){
-
-  ROS_ERROR_STREAM_NAMED("temp","Loading foot polygon with scaling factor " << foot_polygon_scale_);
-
   boost::shared_ptr<const urdf::Link> foot_link =  urdf_model_->getLink(rfoot_mesh_link_name_);
   assert(foot_link);
   boost::shared_ptr<const urdf::Geometry> geom;


### PR DESCRIPTION
Functionally this PR adds an optional constructor variable for the foot_polygon_scale, so that `initFootPolygon` doesn't have to be called a second time after calling `scaleConvexHull()` 

This also renames the variable `scale_convex_hull_` to `foot_polygon_scale_` for clarity. Though perhaps you don't prefer this change.
